### PR TITLE
X509Certificate2.PrivateKey is obsolete and does not provide data

### DIFF
--- a/JWT/JWT.psm1
+++ b/JWT/JWT.psm1
@@ -272,7 +272,13 @@ https://jwt.io/
                 throw "RS256 requires -Cert parameter of type System.Security.Cryptography.X509Certificates.X509Certificate2"
             }
             Write-Verbose "Signing certificate: $($Cert.Subject)"
+            
             $rsa = $Cert.PrivateKey
+
+            if($null -eq $rsa -and 'System.Security.Cryptography.X509Certificates.RSACertificateExtensions' -as [type]) {
+                $rsa = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($Cert)
+            }
+                        
             if ($null -eq $rsa) { # Requiring the private key to be present; else cannot sign!
                 throw "There's no private key in the supplied certificate - cannot sign" 
             }


### PR DESCRIPTION
According to [MS Docs for X509Certificate2.PrivateKey](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2.privatekey?view=net-6.0) PrivateKey-Property is/becomes obsolete and therefore does not provide data anymore.

Instead [RSACertificateExtensions.GetRSAPrivateKey](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.rsacertificateextensions.getrsaprivatekey?view=net-6.0) should be used.